### PR TITLE
Calling this[fn].bind requires extra check - cont.

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -255,7 +255,7 @@
 
 		// Bind all private methods
 		for (var fn in this) {
-			if (fn.charAt(0) === '_' && typeof(this[fn].bind) === 'function') {
+			if (fn.charAt(0) === '_' && typeof(this[fn]) === 'function') {
 				this[fn] = this[fn].bind(this);
 			}
 		}


### PR DESCRIPTION
Checking `typeof(this[fn])` is enough
