### PR TITLE
Module definition improved in knockout-sortable.js

### DIFF
--- a/knockout-sortable.js
+++ b/knockout-sortable.js
@@ -1,56 +1,17 @@
-﻿(function (factory) {
-    "use strict";
-    //get ko ref via global or require
-    var koRef;
-    if (typeof ko !== 'undefined') {
-      //global ref already defined
-      koRef = ko;
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['knockout', 'Sortable'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory(require('knockout'), require('sortablejs'));
+    } else {
+        // Browser globals (root is window)
+        root.returnExports = factory(root.ko, root.Sortable);
     }
-    else if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
-      //commonjs / node.js
-      koRef = require('knockout');
-    }
-    //get sortable ref via global or require
-    var sortableRef;
-    if (typeof Sortable !== 'undefined') {
-      //global ref already defined
-      sortableRef = Sortable;
-    }
-    else if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
-      //commonjs / node.js
-      sortableRef = require('sortablejs');
-    }
-    //use references if we found them
-    if (koRef !== undefined && sortableRef !== undefined) {
-      factory(koRef, sortableRef);
-    }
-    //if both references aren't found yet, get via AMD if available
-    else if (typeof define === 'function' && define.amd){
-      //we may have a reference to only 1, or none
-      if (koRef !== undefined && sortableRef === undefined) {
-        define(['./Sortable'], function(amdSortableRef){ factory(koRef, amdSortableRef); });
-      }
-      else if (koRef === undefined && sortableRef !== undefined) {
-        define(['knockout'], function(amdKnockout){ factory(amdKnockout, sortableRef); });
-      }
-      else if (koRef === undefined && sortableRef === undefined) {
-        define(['knockout', './Sortable'], factory);
-      }
-    }
-    //no more routes to get references
-    else {
-      //report specific error
-      if (koRef !== undefined && sortableRef === undefined) {
-        throw new Error('knockout-sortable could not get reference to Sortable');
-      }
-      else if (koRef === undefined && sortableRef !== undefined) {
-        throw new Error('knockout-sortable could not get reference to Knockout');
-      }
-      else if (koRef === undefined && sortableRef === undefined) {
-        throw new Error('knockout-sortable could not get reference to Knockout or Sortable');
-      }
-    }
-})(function (ko, Sortable) {
+})(this, function (ko, Sortable) {
     "use strict";
 
     var init = function (element, valueAccessor, allBindings, viewModel, bindingContext, sortableOptions) {


### PR DESCRIPTION
Current module definition is bizarre.
`define()`s are not detected by [_r.js_ optimizer](http://requirejs.org/docs/optimization.html), module id is not added, so in the bundle or almond build `knockout-sortable` is not found.

I changed the definition to a cleaner one based on [UMD](https://github.com/umdjs/umd).

This one is correctly processed by _r.js_ and module id is correctly added:
![image](https://cloud.githubusercontent.com/assets/459389/12516443/7efdd35a-c13e-11e5-980b-94eaca093215.png)
